### PR TITLE
revise: incorporate stakeholder answers to planning open questions

### DIFF
--- a/projects/visualise-government-ai-objectives-and-work-in-progress/context/issue.md
+++ b/projects/visualise-government-ai-objectives-and-work-in-progress/context/issue.md
@@ -1,0 +1,14 @@
+# Issue #4: Visualise government ai objectives and work In progress
+
+## Original Issue
+
+Is like to create a way of visualising all of the work that the UK government has:
+
+1. Stated publicly that it will do with AI.
+2. Stated publicly that it is doing or is in progress with AI  
+
+The first set of things will be public announcements, parliamentary statements and the like. The second will be public announcements but also blog posts and news stories. 
+
+I'd like the visualisation to be a web page, with some excellent data visualisations but I want the data backing it to be held in a flexible way that could be used in future to show other visualisations or data exploration. Maybe a graph might be useful. 
+
+I'll need to deploy it somehow as well I guess. 

--- a/projects/visualise-government-ai-objectives-and-work-in-progress/planning/plan.md
+++ b/projects/visualise-government-ai-objectives-and-work-in-progress/planning/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: UK Government AI Visualisation
+
+## Problem Statement
+
+Build a web page that visualises:
+1. **Objectives** — publicly stated AI commitments (announcements, parliamentary statements).
+2. **Work in Progress** — publicly stated ongoing AI work (announcements, blogs, news).
+
+Data must be stored flexibly enough to support future visualisations and graph-based exploration.
+
+## Scope
+
+### In Scope (MVP)
+- Static web page with Chart.js visualisations
+- Two-category data model: objectives / work-in-progress
+- JSON data files as the single source of truth
+- Filters: department, timeframe, plus 1–2 additional fields (defined in design phase)
+- Deployment to Vercel with instructions for the project owner
+- Weekly automated data refresh via GitHub Actions pipeline
+
+### Out of Scope (post-MVP)
+- Graph database backend
+- Authentication or admin UI
+- Real-time data fetching from live sources
+- Full-text search
+
+## Data Sources
+
+| Source | Type | Notes |
+|--------|------|-------|
+| gov.uk | Official announcements, press releases | Primary source |
+| Department blogs (e.g. DSIT, DHSC, MOD) | Blog posts, news | gov.uk-hosted and standalone |
+| GDS AI Studio | Blog posts, GitHub | Not on main gov.uk |
+| i.AI (Incubator for Artificial Intelligence) | Blog posts, publications | Not on main gov.uk |
+
+## Technology Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Data format | JSON | Simple for MVP; schema can mirror a node/edge graph structure for future migration |
+| Visualisation library | Chart.js | Higher-level than D3.js; sufficient for MVP bar, timeline, and donut charts |
+| Deployment | Vercel | Project owner has account; automatic redeploy on git push |
+| Update pipeline | GitHub Actions (scheduled) | Commits refreshed JSON weekly; triggers Vercel redeploy |
+
+## Implementation Tasks
+
+1. **Data schema design** — Define JSON schema for initiatives, including fields for category, department, date, source URL, status, and tags.
+2. **Seed data** — Populate initial JSON with 20–30 curated UK government AI items across both categories.
+3. **Category suggestions** — Propose theme taxonomy (e.g. healthcare, transport, justice, public services, defence) in design phase.
+4. **Web page scaffold** — HTML/CSS/JS static site; load JSON, render with Chart.js.
+5. **Filters** — Implement department filter, timeframe filter, and up to 2 more (e.g. category/theme, initiative type).
+6. **Deployment** — Configure Vercel project, write deployment instructions for project owner.
+7. **Update pipeline** — GitHub Actions workflow on weekly schedule to update data JSON and commit.
+8. **Tests** — Data schema validation tests; basic rendering smoke tests.
+
+## Risks and Dependencies
+
+| Risk | Mitigation |
+|------|-----------|
+| Government data is scattered across many sources | Start with a curated seed set; pipeline handles ongoing discovery |
+| Category taxonomy may not fit all initiatives | Treat taxonomy as v1; allow `tags` array for overflow |
+| Vercel deployment requires owner action | Provide step-by-step instructions; pipeline handles subsequent deploys |
+| Chart.js may not support graph/network views | JSON schema designed for graph migration; graph view deferred to post-MVP |
+
+## Open Questions (Resolved)
+
+All 7 planning open questions resolved — see `review/revision-log.md`.

--- a/projects/visualise-government-ai-objectives-and-work-in-progress/review/revision-log.md
+++ b/projects/visualise-government-ai-objectives-and-work-in-progress/review/revision-log.md
@@ -1,0 +1,38 @@
+# Revision Log
+
+## Revision: 2026-04-01
+
+### Source
+Feedback from @kalbir in issue #4 comment dated 2026-04-01, answering 7 open questions from the planning phase.
+
+### Feedback → Change Mapping
+
+| # | Open Question | Answer | Change |
+|---|---------------|--------|--------|
+| 1 | Data format preference | JSON for MVP | plan.md: data storage specified as JSON files; graph structure deferred post-MVP |
+| 2 | Visualisation library | Chart.js preferred | plan.md: Chart.js confirmed as primary visualisation library; D3.js removed from consideration |
+| 3 | Deployment platform | Vercel; user has account | plan.md: deployment target is Vercel; deployment instructions to be included in implementation |
+| 4 | Update frequency | Weekly | plan.md: weekly data update cadence; CI/CD pipeline to automate data refresh |
+| 5 | Data sources | gov.uk, department blogs, GDS AI Studio, i.AI | plan.md: explicit source list added; i.AI and GDS AI Studio noted as non-gov.uk sources |
+| 6 | Categories/themes | Suggest categories in design, iterate | plan.md: category design delegated to design phase with example suggestions |
+| 7 | Interactivity level | Filter by department, timeframe, ~2 more | plan.md: filters scoped to department, timeframe, and 1–2 additional fields TBD in design |
+
+### Assumptions
+
+- "Some sort of pipeline" for weekly updates is interpreted as a GitHub Actions workflow that commits refreshed JSON data on a schedule; Vercel redeploys automatically on push.
+- i.AI refers to the Prime Minister's AI unit (https://www.gov.uk/government/organisations/incubator-for-artificial-intelligence).
+- GDS AI Studio refers to the Government Digital Service AI team and its public blog/GitHub output.
+- Category suggestions will be proposed in the design phase and are not finalised here.
+- "A couple more" filters beyond department and timeframe is treated as 1–2; exact fields deferred to design.
+
+### Tradeoffs
+
+- JSON chosen over graph DB for MVP simplicity; the schema will be designed to allow future migration to a graph format (e.g. nodes/edges structure within JSON).
+- Chart.js is higher-level than D3.js, which speeds up development but limits bespoke visual forms. Acceptable for MVP.
+- Static site on Vercel keeps infrastructure simple; no backend required for MVP data serving.
+
+### No Changes
+
+- Issue scope (two categories: objectives vs work-in-progress) unchanged.
+- Web page delivery target unchanged.
+- Flexible data backing requirement unchanged.

--- a/projects/visualise-government-ai-objectives-and-work-in-progress/state.json
+++ b/projects/visualise-government-ai-objectives-and-work-in-progress/state.json
@@ -1,0 +1,18 @@
+{
+  "issue_number": 4,
+  "issue_title": "Visualise government ai objectives and work In progress",
+  "project_slug": "visualise-government-ai-objectives-and-work-in-progress",
+  "project_dir": "projects/visualise-government-ai-objectives-and-work-in-progress",
+  "current_stage": "revise",
+  "branch": "claude/issue-4-20260401-1131",
+  "updated_at": "20260401T113500Z",
+  "resolved_decisions": {
+    "data_format": "json",
+    "visualisation_library": "chart.js",
+    "deployment": "vercel",
+    "update_frequency": "weekly",
+    "data_sources": ["gov.uk", "department-blogs", "gds-ai-studio", "i.ai"],
+    "categories": "to-be-proposed-in-design",
+    "filters": ["department", "timeframe", "tbd-1", "tbd-2"]
+  }
+}


### PR DESCRIPTION
Applies feedback from @kalbir resolving all 7 open questions from the planning phase.

- Add planning/plan.md with all decisions resolved (JSON, Chart.js, Vercel, weekly pipeline, data sources, category/filter scope)
- Add review/revision-log.md mapping each feedback item to an explicit change
- Update state.json with resolved decisions

Closes #4

Generated with [Claude Code](https://claude.ai/code)